### PR TITLE
extend URL support to all entries, es6+

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,10 +1,7 @@
-engines: 
+plugins: 
   eslint:
     enabled: true
     channel: "eslint-3"
     config:
-      config: ".eslintrc.json"
+      config: ".eslintrc.yaml"
 
-ratings:
-   paths:
-   - "**.js"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,6 @@
 plugins: 
   eslint:
     enabled: true
-    channel: "eslint-3"
+    channel: "eslint-4"
     config:
       config: ".eslintrc.yaml"
-

--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,10 @@
 
+## 1.0.2 - 2018-03-05
+
+- for MX entries, previously only full email address matches in the file were parsed for LMTP/SMTP routes. Now all MX entries are parsed (email file, email domain, email redis, and domain redis) for URIs.
+- use es6 arrow functions
+- refactored the functions in rcpt() into separate functions (simplify, more testable)
+
 ## 1.0.1 - 2017-08-19
 
 - enable Redis install on AppVeyor CI testing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-recipient-routes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Haraka plugin that validates and routes mail based on recipient domain or address",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- for MX entries, previously only full email address matches in the file were parsed for LMTP/SMTP routes. Now all MX entries are parsed (email file, email domain, email redis, and domain redis) for URIs.
- use es6 arrow functions
- refactored the functions in rcpt() into separate functions (simplify, more testable)