### PR TITLE
Add Option to Disable Redis

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- add redis disabled option
+
 ### [1.1.0] - 2022-11-22
 
 - fix: use this.redis_ping during runtime, #26

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,6 @@
 ### Unreleased
 
-- add redis disabled option
+- add redis enabled setting
 
 ### [1.1.0] - 2022-11-22
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Recipient Routes does recipient validation and MX routing.
 
 Recipients can be listed in the [routes] section of the config file
 `config/rcpt_to.routes.ini` or in Redis. If Redis is available, it is checked
-first. Then the config file is checked.  However, if Redis is disabled in
+first. Then the config file is checked.  However, if Redis is not enabled in
 settings then only the config file is checked.
 
 Entries can be email addresses or domains. If both are present, email
@@ -56,7 +56,7 @@ The [redis] section has four optional settings (defaults shown):
     host=127.0.0.1
     port=6379
     db=0
-    disabled=false
+    enabled=true
 
 ### Routes
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Recipient Routes does recipient validation and MX routing.
 ## Recipient Validation
 
 Recipients can be listed in the [routes] section of the config file
-`config/rcpt_to.routes.ini` or in Redis. If Redis is available, it is checked
-first. Then the config file is checked.  However, if Redis is not enabled in
-settings then only the config file is checked.
+`config/rcpt_to.routes.ini` or in Redis. If Redis is enabled and available, it is checked
+first. Then the config file is checked.
 
 Entries can be email addresses or domains. If both are present, email
 addresses are favored.

--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ The following options can be specified in `config/rcpt_to.routes.ini`:
 
 ### Redis
 
-The [redis] section has three optional settings (defaults shown):
+The [redis] section has four optional settings (defaults shown):
 
     [redis]
     host=127.0.0.1
     port=6379
     db=0
+    disabled=false
 
 ### Routes
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following options can be specified in `config/rcpt_to.routes.ini`:
 
 ### Redis
 
-The [redis] section has four optional settings (defaults shown):
+The [redis] section has optional settings (defaults shown):
 
     [redis]
     host=127.0.0.1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Recipient Routes does recipient validation and MX routing.
 
 Recipients can be listed in the [routes] section of the config file
 `config/rcpt_to.routes.ini` or in Redis. If Redis is available, it is checked
-first. Then the config file is checked.
+first. Then the config file is checked.  However, if Redis is disabled in
+settings then only the config file is checked.
 
 Entries can be email addresses or domains. If both are present, email
 addresses are favored.

--- a/config/rcpt_to.routes.ini
+++ b/config/rcpt_to.routes.ini
@@ -3,6 +3,7 @@
 ; host=127.0.0.1
 ; port=6379
 ; db=0
+; disabled=false
 
 ; [routes]
 ; matt@example.com=192.168.76.66

--- a/config/rcpt_to.routes.ini
+++ b/config/rcpt_to.routes.ini
@@ -3,7 +3,7 @@
 ; host=127.0.0.1
 ; port=6379
 ; db=0
-; disabled=false
+; enabled=true
 
 ; [routes]
 ; matt@example.com=192.168.76.66

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ exports.load_rcpt_to_routes_ini = function () {
   plugin.cfg.redis.opts = {
     host: plugin.cfg.redis.server_ip || plugin.cfg.redis.host || '127.0.0.1',
     port: plugin.cfg.redis.server_port || plugin.cfg.redis.port || 6379,
-    enabled: plugin.cfg.redis.enabled || true
+    enabled: plugin.cfg.redis.enabled ?? true,
   }
 
   const lowered = {};

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ exports.register = function () {
   this.route_list={};
 
   this.load_rcpt_to_routes_ini();
-  if (!this.cfg.redis.opts.disabled) {
+  if (this.cfg.redis.opts.enabled) {
     this.merge_redis_ini();
     this.redis_ping();
 
@@ -35,7 +35,7 @@ exports.load_rcpt_to_routes_ini = function () {
   plugin.cfg.redis.opts = {
     host: plugin.cfg.redis.server_ip || plugin.cfg.redis.host || '127.0.0.1',
     port: plugin.cfg.redis.server_port || plugin.cfg.redis.port || 6379,
-    disabled: plugin.cfg.redis.disabled || false
+    enabled: plugin.cfg.redis.enabled || true
   }
 
   const lowered = {};
@@ -109,7 +109,7 @@ exports.rcpt = async function (next, connection, params) {
   }
 
   // if we can't use redis, try files
-  if (this.cfg.redis.opts.disabled || !this.db || !await this.redis_ping()) {
+  if (!this.cfg.redis.opts.enabled || !this.db || !await this.redis_ping()) {
     return next(await this.do_file_search(txn, address, domain));
   }
 
@@ -167,7 +167,7 @@ exports.get_mx = async function (next, hmail, domain) {
   }
 
   // if we can't use redis, try files and return
-  if (this.cfg.redis.opts.disabled || !this.db || !await this.redis_ping()) {
+  if (!this.cfg.redis.opts.enabled || !this.db || !await this.redis_ping()) {
     this.get_mx_file(address, domain, next);
     return;
   }
@@ -194,13 +194,13 @@ exports.get_mx = async function (next, hmail, domain) {
 
 exports.insert_route = function (email, route) {
   // for importing, see http://redis.io/topics/mass-insert
-  if (this.cfg.redis.opts.disabled || !this.db || !this.redis_pings) return false;
+  if (!this.cfg.redis.opts.enabled || !this.db || !this.redis_pings) return false;
 
   this.db.set(email, route);
 }
 
 exports.delete_route = function (email) {
-  if (this.cfg.redis.opts.disabled || !this.redis_pings) return false;
+  if (!this.cfg.redis.opts.enabled || !this.redis_pings) return false;
 
   this.db.del(email);
 }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ exports.register = function () {
   this.load_rcpt_to_routes_ini();
   if (this.cfg.redis.opts.enabled) {
     this.merge_redis_ini();
-    this.redis_ping();
 
     this.register_hook('init_master',  'init_redis_plugin');
     this.register_hook('init_child',   'init_redis_plugin');

--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ exports.register = function () {
 
 exports.load_rcpt_to_routes_ini = function () {
   const plugin = this;
-  plugin.cfg = plugin.config.get('rcpt_to.routes.ini', function () {
+  plugin.cfg = plugin.config.get('rcpt_to.routes.ini', {
+      booleans: [
+          '+main.enabled',
+      ],
+  },
+  function () {
     plugin.load_rcpt_to_routes_ini();
   })
 

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ exports.rcpt = async function (next, connection, params) {
   }
 
   // if we can't use redis, try files
-  if (this.cfg.redis.opts.disabled || (!!this.db && ! await this.redis_ping())) {
+  if (this.cfg.redis.opts.disabled || !this.db || !await this.redis_ping()) {
     return next(await this.do_file_search(txn, address, domain));
   }
 
@@ -167,7 +167,7 @@ exports.get_mx = async function (next, hmail, domain) {
   }
 
   // if we can't use redis, try files and return
-  if (this.cfg.redis.opts.disabled || (!!this.db && !await this.redis_ping())) {
+  if (this.cfg.redis.opts.disabled || !this.db || !await this.redis_ping()) {
     this.get_mx_file(address, domain, next);
     return;
   }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ exports.load_rcpt_to_routes_ini = function () {
   const plugin = this;
   plugin.cfg = plugin.config.get('rcpt_to.routes.ini', {
       booleans: [
-          '+main.enabled',
+          '+redis.enabled',
       ],
   },
   function () {


### PR DESCRIPTION
The latest version of recipient-routes causes a plugin timeout on startup when Redis is not available (or at least it does on Windows).  While this patch is likely overkill for that particular problem, I've always wanted a way to disable Redis anyway since I hardly ever use it.